### PR TITLE
Move back to the top of the buffer when done

### DIFF
--- a/yari.el
+++ b/yari.el
@@ -150,6 +150,7 @@
   (setq mode-name "yari")
   (setq major-mode 'yari-mode)
   (yari-find-buttons)
+  (goto-char (point-min))
   (setq buffer-read-only t)
   (run-hooks 'yari-mode-hook))
 


### PR DESCRIPTION
I think my button modification leaves the cursor at the bottom of the buffer which is not nice.  This adds a simple move to point-min.
