### PR TITLE
Use RI environment variable

### DIFF
--- a/yari.el
+++ b/yari.el
@@ -235,7 +235,7 @@
             (cond
              ((yari-ri-version-at-least "2.5")
                "require 'rdoc/ri/driver';       \
-                driver  = RDoc::RI::Driver.new; \
+                driver  = RDoc::RI::Driver.new(RDoc::RI::Driver.process_args([])); \
                 puts driver.list_known_classes; \
                 puts driver.list_methods_matching('.')")
               ((yari-ri-version-at-least "2.2.0")


### PR DESCRIPTION
With this relatively simple change, a user can now use the RI
environment variable.  I did this because I wanted access to the
--doc-dir argument but this simple addition opens the door for users to
set any RI options they may want.