### PR TITLE
Select window with ri-buffer after opening it

### DIFF
--- a/yari.el
+++ b/yari.el
@@ -128,7 +128,7 @@
           (ansi-color-apply-on-region (point-min) (point-max))
           (goto-char (point-min))
           (yari-mode))))
-    (display-buffer yari-buffer-name)))
+    (pop-to-buffer yari-buffer-name)))
 
 (defun yari-symbol-at-point ()
   ;; TODO: make this smart about class/module at point


### PR DESCRIPTION
This way you don't have to switch windows
to close the ruby-doc buffer.