### PR TITLE
Fix ri command invocation to resolve character escape issues

### DIFF
--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -9,4 +9,16 @@
               (yari-ruby-obarray-cache ,cache-mock))
          ,@body)))
 
+(defun yari-test-command (name)
+  (let* ((mock (lambda (&rest _args) name)))
+    (cl-letf (((symbol-function 'completing-read) mock)
+              ((symbol-function 'ido-completing-read) mock))
+      (with-temp-buffer
+        (yari)
+        (switch-to-buffer (format "*yari %s*" name))
+        (should (string-prefix-p name
+                                 (buffer-substring-no-properties
+                                  (point-min)
+                                  (point-max))))))))
+
 ;;; test-helper.el ends here

--- a/test/yari-test.el
+++ b/test/yari-test.el
@@ -68,4 +68,13 @@
 (ert-deftest yari-test-get-ri-version-for-2.5.6 ()
   (should (equal "2.5.6" (yari-get-ri-version "ri 2.5.6"))))
 
+(ert-deftest yari-test-command-class ()
+  (yari-test-command "String"))
+
+(ert-deftest yari-test-command-method ()
+  (yari-test-command "String#chomp"))
+
+(ert-deftest yari-test-command-ampersand-operator ()
+  (yari-test-command "Array#&"))
+
 ;;; yari-test.el ends here

--- a/yari.el
+++ b/yari.el
@@ -161,9 +161,12 @@
   "Return content from ri for NAME."
   (cl-assert (member name (yari-ruby-obarray)) nil
           (format "%s is unknown symbol to RI." name))
-  (shell-command-to-string
-   (concat yari-ri-program-name " -T -f ansi \""
-           (shell-quote-argument name) "\"")))
+  (with-temp-buffer
+    (call-process (executable-find yari-ri-program-name)
+                  nil (current-buffer) nil
+                  "-T" "-f" "ansi"
+                  name)
+    (buffer-string)))
 
 (defvar yari-ruby-obarray-cache nil
   "Variable to store all possible completions of RI pages.")


### PR DESCRIPTION
This is a fix for calling the ri command and is a continuation from #17.

I noticed that the change did not solve the problem when I restart Emacs and use the `yari` command.  On the contrary, queries for normal methods (e.g. `String#chomp`) were also broken...

It seems that using `shell-command-to-string` (with `shell-quote-argument`) is difficult to solve the problem, so I changed to the `call-process` approach.  Also, tests have been added to confirm the behaviour.